### PR TITLE
Prevent image from stretching past 100%

### DIFF
--- a/styles/prosilver/template/donate_stats.html
+++ b/styles/prosilver/template/donate_stats.html
@@ -8,7 +8,7 @@
 <div class="progress">
 	<div class="progress-value">{PPDE_GOAL_NUMBER} %</div>
 	<div class="progress-grey">
-		<div class="prog-color {PPDE_CSS_GOAL_NUMBER}" style="width: {PPDE_GOAL_NUMBER}%;"></div>
+		<div class="prog-color {PPDE_CSS_GOAL_NUMBER}" style="width: <!-- IF PPDE_GOAL_NUMBER > 100 -->100<!-- ELSE -->{PPDE_GOAL_NUMBER}<!-- ENDIF -->%;"></div>
 	</div>
 </div>
 <!-- ENDIF -->


### PR DESCRIPTION
This won't change the numbers displayed.  Only the progress bar not going past 100%